### PR TITLE
ci: remove CI github action on push

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main, dev]
   pull_request:
     branches: [main, dev]
 


### PR DESCRIPTION
## Resumen

Remueve ejecución de GitHub Action de CI cuando se hace push. La deja habilitada solo para PRs.

## ¿Algo más que agregar?
 
Las ramas asociadas están protegidas contra los push de todos modos.