### PR TITLE
feat: added login view, redirection handling and landingpage mock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ yarn-error.*
 
 expo-env.d.ts
 app-example
+
+indextest.tsx
+```

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "expo-constants": "~16.0.2",
         "expo-font": "~12.0.9",
         "expo-linking": "~6.3.1",
-        "expo-router": "~3.5.23",
+        "expo-router": "~3.5.24",
         "expo-splash-screen": "~0.27.5",
         "expo-status-bar": "~1.12.1",
         "expo-system-ui": "~3.0.7",
@@ -2960,9 +2960,9 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "0.18.30",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.18.30.tgz",
-      "integrity": "sha512-V90TUJh9Ly8stYo8nwqIqNWCsYjE28GlVFWEhAFCUOp99foiQr8HSTpiiX5GIrprcPoWmlGoY+J5fQA29R4lFg==",
+      "version": "0.18.31",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.18.31.tgz",
+      "integrity": "sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
@@ -3159,9 +3159,9 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-8.0.10.tgz",
-      "integrity": "sha512-KG1fnSKRmsudPU9BWkl59PyE0byrE2HTnqbOrgwr2FAhqh7tfr9nRs6A9oLS/ntpGzmFxccTEcsV0L4apsuxxg==",
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-8.0.11.tgz",
+      "integrity": "sha512-oALE1HwnLFthrobAcC9ocnR9KXLzfWEjgIe4CPe+rDsfC6GDs8dGYCXfRFoCEzoLN4TGYs9RdZ8r0KoCcNrm2A==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-types": "^51.0.3",
@@ -7622,12 +7622,12 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.13.1.tgz",
-      "integrity": "sha512-2ly7bENj2n2FNBdEN60ZEbNCs5dAOex/QJoo6EZ8RNFfUQxVKAZkMwfQ4ETV2SLWDgkRLj3Jo5n/dx7O2ZGhGw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.14.0.tgz",
+      "integrity": "sha512-ou16LMJYv0ElIToZ6dDqaLjv1T3iBEwuJTBahveEA8NkkACIWODJ2fgUYf1UKLMKHVdHjNImLzS37HdSZY0Q6g==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/server-runtime": "2.13.1",
+        "@remix-run/server-runtime": "2.14.0",
         "@remix-run/web-fetch": "^4.4.2",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie-signature": "^1.1.0",
@@ -7648,21 +7648,21 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.20.0.tgz",
-      "integrity": "sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.0.tgz",
+      "integrity": "sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.13.1.tgz",
-      "integrity": "sha512-2DfBPRcHKVzE4bCNsNkKB50BhCCKF73x+jiS836OyxSIAL+x0tguV2AEjmGXefEXc5AGGzoxkus0AUUEYa29Vg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.14.0.tgz",
+      "integrity": "sha512-9Th9UzDaoFFBD7zA5mRI1KT8JktFLN4ij9jPygrKBhG/kYmNIvhcMtq9VyjcbMvFK5natTyhOhrrKRIHtijD4w==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.20.0",
+        "@remix-run/router": "1.21.0",
         "@types/cookie": "^0.6.0",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.6.0",
@@ -12476,15 +12476,15 @@
       }
     },
     "node_modules/expo": {
-      "version": "51.0.38",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-51.0.38.tgz",
-      "integrity": "sha512-/B9npFkOPmv6WMIhdjQXEY0Z9k/67UZIVkodW8JxGIXwKUZAGHL+z1R5hTtWimpIrvVhyHUFU3f8uhfEKYhHNQ==",
+      "version": "51.0.39",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-51.0.39.tgz",
+      "integrity": "sha512-Cs/9xopyzJrpXWbyVUZnr37rprdFJorRgfSp6cdBfvbjxZeKnw2MEu7wJwV/s626i5lZTPGjZPHUF9uQvt51cg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "0.18.30",
+        "@expo/cli": "0.18.31",
         "@expo/config": "9.0.4",
-        "@expo/config-plugins": "8.0.10",
+        "@expo/config-plugins": "8.0.11",
         "@expo/metro-config": "0.18.11",
         "@expo/vector-icons": "^14.0.3",
         "babel-preset-expo": "~11.0.15",
@@ -12702,10 +12702,9 @@
       }
     },
     "node_modules/expo-router": {
-      "version": "3.5.23",
-      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-3.5.23.tgz",
-      "integrity": "sha512-Re2kYcxov67hWrcjuu0+3ovsLxYn79PuX6hgtYN20MgigY5ttX79KOIBEVGTO3F3y9dxSrGHyy5Z14BcO+usGQ==",
-      "license": "MIT",
+      "version": "3.5.24",
+      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-3.5.24.tgz",
+      "integrity": "sha512-wFi+PIUrOntF5cgg0PgBMlkxEZlWedIv5dWnPFEzN6Tr3A3bpsqdDLgOEIwvwd+pxn5DLzykTmg9EkQ1pPGspw==",
       "dependencies": {
         "@expo/metro-runtime": "3.2.3",
         "@expo/server": "^0.4.0",
@@ -12713,7 +12712,7 @@
         "@react-navigation/bottom-tabs": "~6.5.7",
         "@react-navigation/native": "~6.1.6",
         "@react-navigation/native-stack": "~6.9.12",
-        "expo-splash-screen": "0.27.5",
+        "expo-splash-screen": "0.27.7",
         "react-native-helmet-async": "2.0.4",
         "schema-utils": "^4.0.1"
       },
@@ -12739,174 +12738,15 @@
         }
       }
     },
-    "node_modules/expo-router/node_modules/@expo/prebuild-config": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-7.0.6.tgz",
-      "integrity": "sha512-Hts+iGBaG6OQ+N8IEMMgwQElzJeSTb7iUJ26xADEHkaexsucAK+V52dM8M4ceicvbZR9q8M+ebJEGj0MCNA3dQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~9.0.0-beta.0",
-        "@expo/config-plugins": "~8.0.0-beta.0",
-        "@expo/config-types": "^51.0.0-unreleased",
-        "@expo/image-utils": "^0.5.0",
-        "@expo/json-file": "^8.3.0",
-        "@react-native/normalize-colors": "0.74.84",
-        "debug": "^4.3.1",
-        "fs-extra": "^9.0.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.6.0",
-        "xml2js": "0.6.0"
-      },
-      "peerDependencies": {
-        "expo-modules-autolinking": ">=0.8.1"
-      }
-    },
-    "node_modules/expo-router/node_modules/@react-native/normalize-colors": {
-      "version": "0.74.84",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.84.tgz",
-      "integrity": "sha512-Y5W6x8cC5RuakUcTVUFNAIhUZ/tYpuqHZlRBoAuakrTwVuoNHXfQki8lj1KsYU7rW6e3VWgdEx33AfOQpdNp6A==",
-      "license": "MIT"
-    },
-    "node_modules/expo-router/node_modules/expo-splash-screen": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-0.27.5.tgz",
-      "integrity": "sha512-9rdZuLkFCfgJBxrheUsOEOIW6Rp+9NVlpSE0hgXQwbTCLTncf00IHSE8/L2NbFyeDLNjof1yZBppaV7tXHRUzA==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/prebuild-config": "7.0.6"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-router/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/expo-router/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/expo-router/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/expo-router/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/expo-splash-screen": {
-      "version": "0.27.6",
-      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-0.27.6.tgz",
-      "integrity": "sha512-joUwZQS48k3VMnucQ0Y8Dle1t1FyIvluQA4kjuPx2x7l2dRrfctbo34ahTnC0p1o2go5oN2iEnSTOElY4wRQHw==",
-      "license": "MIT",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-0.27.7.tgz",
+      "integrity": "sha512-s+eGcG185878nixlrjhhLD6UDYrvoqBUaBkIEozBVWFg3pkdsKpONPiUAco4XR3h7I/9ODq4quN28RJLFO+s0Q==",
       "dependencies": {
-        "@expo/prebuild-config": "7.0.8"
+        "@expo/prebuild-config": "7.0.9"
       },
       "peerDependencies": {
         "expo": "*"
-      }
-    },
-    "node_modules/expo-splash-screen/node_modules/@expo/prebuild-config": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-7.0.8.tgz",
-      "integrity": "sha512-wH9NVg6HiwF5y9x0TxiMEeBF+ITPGDXy5/i6OUheSrKpPgb0lF1Mwzl/f2fLPXBEpl+ZXOQ8LlLW32b7K9lrNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~9.0.0-beta.0",
-        "@expo/config-plugins": "~8.0.8",
-        "@expo/config-types": "^51.0.0-unreleased",
-        "@expo/image-utils": "^0.5.0",
-        "@expo/json-file": "^8.3.0",
-        "@react-native/normalize-colors": "0.74.85",
-        "debug": "^4.3.1",
-        "fs-extra": "^9.0.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.6.0",
-        "xml2js": "0.6.0"
-      },
-      "peerDependencies": {
-        "expo-modules-autolinking": ">=0.8.1"
-      }
-    },
-    "node_modules/expo-splash-screen/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/expo-splash-screen/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/expo-splash-screen/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/expo-splash-screen/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/expo-status-bar": {
@@ -22108,9 +21948,9 @@
       "license": "ISC"
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.0.tgz",
-      "integrity": "sha512-lXLOiqpkUumhRdFF3k1osNXCy9akgx/dyPZ5p8qAg9seJzXr5ZrlqZuWIMuY6ejOsVLE6flJ5/h3lsn57fQ/PQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
       "license": "MIT"
     },
     "node_modules/set-function-length": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "expo-constants": "~16.0.2",
     "expo-font": "~12.0.9",
     "expo-linking": "~6.3.1",
-    "expo-router": "~3.5.23",
+    "expo-router": "~3.5.24",
     "expo-splash-screen": "~0.27.5",
     "expo-status-bar": "~1.12.1",
     "expo-system-ui": "~3.0.7",

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,10 +1,15 @@
-import { Slot } from 'expo-router';
+import { Slot, Stack } from 'expo-router';
 import AuthProvider from '../components/contexts/AuthContext';
 
 export default function RootLayout() {
   return (
     <AuthProvider>
-      <Slot />
+      {/* <Slot /> */}
+      {/* se intercambio usar el ruteo de Slot por Stack por mejor documentacion, hablar con Benja */}
+      <Stack>
+        <Stack.Screen name="login" />
+        <Stack.Screen name="register" />
+      </Stack>
     </AuthProvider>
   );
 }

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,13 +1,13 @@
-import React, { useCallback, useContext, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
-import { useFocusEffect } from 'expo-router';
+import { useFocusEffect, useRouter } from 'expo-router';
 import api from '@/api';
 import { AuthContext } from '@/components/contexts/AuthContext';
-import LoginForm from '@/components/LoginForm';
 
 export default function Index() {
   const [backendGreeting, setBackendGreeting] = useState<string>('');
   const { userId, token } = useContext(AuthContext);
+  const router = useRouter();
 
   useFocusEffect(
     useCallback(() => {
@@ -20,6 +20,10 @@ export default function Index() {
         }
       }
       getBackendGreeting();
+
+      if (!userId) {
+        router.push('/login');
+      }
     }, []),
   );
 
@@ -31,14 +35,27 @@ export default function Index() {
           : 'No greetings available from backend :'}
       </Text>
 
-      {userId ? (
+      {
+        <>
+          if (userId){' '}
+          {
+            <>
+              <Text>Welcome back, User {userId}!</Text>
+              <Text>Your token is: {token}</Text>
+            </>
+          }
+        </>
+      }
+
+      {/* {userId ? (
         <>
           <Text>Welcome back, User {userId}!</Text>
           <Text>Your token is: {token}</Text>
         </>
       ) : (
+        // router.replace('/login');
         <LoginForm />
-      )}
+      )} */}
     </View>
   );
 }

--- a/src/app/landingpage.tsx
+++ b/src/app/landingpage.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import { Button, Text, View } from 'react-native';
+// import jwtDecode from 'jwt-decode';
+// import AsyncStorage from '@react-native-async-storage/async-storage';  // instalar en consola
+import { useFocusEffect, useRouter } from 'expo-router';
+
+// aqui hay muchas lineas comentadas porque tengo que instalar unas dependencias
+
+const LandingPage = () => {
+  const [userId, setUserId] = useState<string>('');
+  const router = useRouter();
+
+  // useEffect(() => {
+  //     const fetchUserData = async () => {
+  //     const token = await AsyncStorage.getItem('token');
+  //     if (token) {
+  //         const decodedToken = jwtDecode(token);
+  //         setUserId(decodedToken.userId);
+  //     } else {
+  //         router.push('/login');
+  //     }
+  //     };
+  //     fetchUserData();
+  // }, []);
+
+  const handleLogout = async () => {
+    // await AsyncStorage.removeItem('token');
+    router.push('/login');
+  };
+
+  return (
+    <View>
+      {userId ? (
+        <>
+          <Text>Welcome back, User {userId}!</Text>
+
+          {/*                   IDEAS 
+                    
+                    - Crear una componente HabitCard para desplegar todas las tarjetas
+                    - Considerar ruteo dinamico de expo con cards/[id].tsx
+                    - Crear una componente HabitForm para agregar habitos --> quizas en la navbar?
+                    - Quizás aparte del userFetchData, hacer un fetch de las estadísticas por separado
+                    
+                    */}
+
+          {/* <Text>Your token is: {token}</Text> */}
+          <Button title="Logout" onPress={handleLogout} />
+        </>
+      ) : (
+        <Text>Redirecting to login...</Text>
+      )}
+    </View>
+  );
+};
+
+export default LandingPage;

--- a/src/app/login.tsx
+++ b/src/app/login.tsx
@@ -1,0 +1,59 @@
+// src/app/login.tsx
+
+import React, { useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import LoginForm from '../components/LoginForm';
+import { useRouter } from 'expo-router';
+import api from '@/api';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [username, setUsername] = useState('');
+  const status = '';
+  const router = useRouter();
+
+  // falta arreglar handleLogin: corregir el status, evaluar cambiar todo eso a register y probar la API
+  // OJO este codigo esta duplicado con LoginForm
+  const handleLogin = async () => {
+    try {
+      const response = await api.login(email, password, username, status); // VERIFICAR BEN ESTO
+      if (response.token) {
+        // esto es solo una idea, buscar una forma de guardar el token en el contexto
+        // await AsyncStorage.setItem('token', response.token);
+
+        router.push('/landingpage');
+      } else {
+        console.log('Login failed. Please check your credentials.');
+      }
+    } catch (error) {
+      console.error(error);
+      console.log('Login failed. Please check your credentials.');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      {/* aquí poner un logo para habitualize */}
+      <Text style={styles.title}>Login</Text>
+      <LoginForm />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    marginBottom: 16,
+    color: '#22a098',
+  },
+});

--- a/src/app/register.tsx
+++ b/src/app/register.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import LoginForm from '../components/LoginForm';
+import { useRouter } from 'expo-router';
+
+export default function Register() {
+  const navigation = useNavigation();
+  const router = useRouter();
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Register</Text>
+      <LoginForm />
+      <Text onPress={() => router.push('/login')}>
+        Already have an account? Login here
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f8f9f9',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 16,
+    color: '#333',
+  },
+});

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,6 +1,8 @@
 import React, { useContext, useState } from 'react';
-import { Button, Text, TextInput, View } from 'react-native';
+import { Button, StyleSheet, Text, TextInput, View } from 'react-native';
 import { AuthContext } from './contexts/AuthContext';
+import api from '@/api';
+import { useRouter } from 'expo-router';
 
 export default function LoginForm() {
   const { login, createUser } = useContext(AuthContext);
@@ -9,12 +11,22 @@ export default function LoginForm() {
   const [username, setUsername] = useState('');
   const [error, setError] = useState<string | null>(null);
 
+  const router = useRouter();
+
   const handleLogin = async () => {
     try {
-      // get response from login
-      await login(email, password, username);
+      const response = await api.login(email, password, username, status); // VERIFICAR BEN ESTO
+      if (response.token) {
+        // esto es solo una idea, buscar una forma de guardar el token en el contexto
+        // await AsyncStorage.setItem('token', response.token);
+
+        router.push('/landingpage');
+      } else {
+        console.log('Login failed. Please check your credentials.');
+      }
     } catch (error) {
-      setError('Login failed. Please check your credentials.');
+      console.error(error);
+      console.log('Login failed. Please check your credentials.');
     }
   };
 
@@ -27,32 +39,59 @@ export default function LoginForm() {
     }
   };
   return (
-    <View>
-      <TextInput
-        placeholder="Email"
-        value={email}
-        onChangeText={setEmail}
-        autoCapitalize="none"
-        keyboardType="email-address"
-      />
-      <TextInput
-        placeholder="Username"
-        value={username}
-        onChangeText={setUsername}
-        autoCapitalize="none"
-      />
-      <TextInput
-        placeholder="Password"
-        value={password}
-        onChangeText={setPassword}
-        secureTextEntry={true}
-      />
-      <Button title="Login" onPress={handleLogin} />
+    <div style={styles.container}>
+      <View>
+        <TextInput
+          placeholder="Email"
+          value={email}
+          onChangeText={setEmail}
+          autoCapitalize="none"
+          keyboardType="email-address"
+          style={styles.input}
+        />
+        <TextInput
+          placeholder="Username"
+          value={username}
+          onChangeText={setUsername}
+          autoCapitalize="none"
+          style={styles.input}
+        />
+        <TextInput
+          placeholder="Password"
+          value={password}
+          onChangeText={setPassword}
+          secureTextEntry={true}
+          style={styles.input}
+        />
 
-      <Text>Don't have an account?</Text>
-      <Button title="Create Account" onPress={handleCreateAccount} />
+        <Button title="Login" onPress={handleLogin} />
 
-      {error && <Text>{error}</Text>}
-    </View>
+        <Text>Don't have an account?</Text>
+
+        <Button title="Create Account" onPress={handleCreateAccount} />
+
+        {error && <Text>{error}</Text>}
+      </View>
+    </div>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 32,
+    backgroundColor: '#f4fdfc',
+    borderRadius: 6,
+  },
+  input: {
+    height: 40,
+    margin: 12,
+    backgroundColor: '#dafef6',
+    /* placeholderTextColor: 'grey', */
+    borderRadius: 6,
+    fontSize: 16,
+  },
+  button: {
+    color: '#22a098',
+  },
+});


### PR DESCRIPTION
## Resumen

_Descripción general_

## Cambios

- Agregar una vista al login, se hizo a mano más o menos imitando al figma (los botones fueron imposibles de cambiar ups)
- conectar bien las rutas, es decir al abrir la app pasar de "/" a "/login" al tiro, y luego de "/login" a "/landingpage", fue larguísimo porque no cachaba nada de como funcionaba Expo pero es bacán
- hacer una **MAQUETA** de lo que sería el landing page, y sus funciones de fetchdata



## ¿Algo más que agregar?
 
Perdón todos los comentarios y hacer todo en un puro commit, pero tenía que ordenarme antes de sacar todo jajaj